### PR TITLE
fix: Start using sequelize migrations

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,25 @@
+require("dotenv").config();
+
+module.exports = {
+  "development": {
+    "username": process.env.MARIADB_USER,
+    "password": process.env.MARIADB_PASS,
+    "database": process.env.MARIADB_DB,
+    "host": process.env.MARIADB_HOST,
+    "dialect": "mariadb"
+  },
+  "test": {
+    "username": process.env.MARIADB_USER,
+    "password": process.env.MARIADB_PASS,
+    "database": process.env.MARIADB_DB,
+    "host": process.env.MARIADB_HOST,
+    "dialect": "mariadb"
+  },
+  "production": {
+    "username": process.env.MARIADB_USER,
+    "password": process.env.MARIADB_PASS,
+    "database": process.env.MARIADB_DB,
+    "host": process.env.MARIADB_HOST,
+    "dialect": "mariadb"
+  }
+}

--- a/migrations/20250427173103-init-models.js
+++ b/migrations/20250427173103-init-models.js
@@ -1,0 +1,181 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    const tables = await queryInterface.showAllTables();
+
+    if (!tables.includes("discord_user")) {
+      await queryInterface.createTable("discord_user", {
+        id: {
+          type: Sequelize.STRING(20),
+          primaryKey: true,
+        },
+        username: {
+          type: Sequelize.STRING(32),
+          allowNull: false,
+        },
+        discriminator: {
+          type: Sequelize.STRING(4),
+          allowNull: true,
+        },
+        global_name: {
+          type: Sequelize.STRING(32),
+          allowNull: true,
+        },
+        avatar: {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        createdAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+        },
+        updatedAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+        }
+      });
+    }
+
+    if (!tables.includes("discord_guild")) {
+      await queryInterface.createTable("discord_guild", {
+        id: {
+          type: Sequelize.STRING(20),
+          primaryKey: true,
+        },
+        ownerId: {
+          type: Sequelize.STRING(20),
+          allowNull: false,
+          references: {
+            model: "discord_user",
+            key: "id",
+          }
+        },
+        name: {
+          type: Sequelize.STRING(100),
+          allowNull: false,
+        },
+        nameAcronym: {
+          type: Sequelize.STRING(5),
+          allowNull: true,
+        },
+        description: {
+          type: Sequelize.STRING(120),
+          allowNull: true,
+        },
+        icon: {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        banner: {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        createdAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+        },
+        updatedAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+        }
+      });
+    }
+
+    if (!tables.includes("discord_channel")) {
+      await queryInterface.createTable('discord_channel', {
+        id: {
+          type: Sequelize.STRING(20),
+          primaryKey: true,
+        },
+        type: {
+          type: Sequelize.ENUM,
+          values: ['master_category', 'master_channel', 'child_channel'],
+          allowNull: false,
+        },
+        status: {
+          type: Sequelize.ENUM,
+          values: ['public', 'private', 'hidden'],
+          defaultValue: 'public',
+          allowNull: false,
+        },
+        members: {
+          type: Sequelize.STRING,
+          allowNull: true,
+        },
+        masterChannelId: {
+          type: Sequelize.STRING(20),
+          references: {
+            model: "discord_channel",
+            key: "id",
+            onDelete: "CASCADE",
+            allowNull: true,
+          },
+        },
+        guildId: {
+          type: Sequelize.STRING(20),
+          references: {
+            model: "discord_guild",
+            key: "id",
+          },
+          onDelete: "CASCADE",
+          allowNull: false,
+        },
+        ownerId: {
+          type: Sequelize.STRING(20),
+          references: {
+            model: "discord_user",
+            key: "id",
+          },
+          allowNull: true,
+        },
+        createdAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+        },
+        updatedAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+        }
+      });
+    }
+
+    if (!tables.includes("discord_message")) {
+      await queryInterface.createTable('discord_message', {
+        id: {
+          type: Sequelize.STRING(20),
+          primaryKey: true,
+        },
+        channelId: {
+          type: Sequelize.STRING(20),
+          allowNull: false,
+        },
+        panelChannelId: {
+          type: Sequelize.STRING(20),
+          references: {
+            model: "discord_channel",
+            key: "id",
+          },
+          onDelete: "CASCADE",
+          allowNull: true,
+        },
+        createdAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+        },
+        updatedAt: {
+          type: Sequelize.DATE,
+          allowNull: false,
+        }
+      });
+    }
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('discord_message');
+    await queryInterface.dropTable('discord_channel');
+    await queryInterface.dropTable('discord_guild');
+    await queryInterface.dropTable('discord_user');
+  }
+};

--- a/migrations/20250427174404-add-naming-scheme-to-discord-channel.js
+++ b/migrations/20250427174404-add-naming-scheme-to-discord-channel.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    const allColumns = await queryInterface.describeTable("discord_channel");
+    if (allColumns.namingScheme) return;
+
+    await queryInterface.addColumn("discord_channel", "namingScheme", {
+      type: Sequelize.STRING(100),
+      allowNull: true,
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    // We are using raw SQL here because Sequelize has issues with dropping columns with the MariaDB dialect
+    // This will need to be changed if we start supporting other databases
+    await queryInterface.sequelize.query(
+        'ALTER TABLE discord_channel DROP COLUMN namingScheme'
+    );
+  }
+};

--- a/models/index.js
+++ b/models/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
+const process = require('process');
+const basename = path.basename(__filename);
+const env = process.env.NODE_ENV || 'development';
+const config = require(__dirname + '/../config/config.json')[env];
+const db = {};
+
+let sequelize = new Sequelize(config.database, config.username, config.password, config);
+
+db.sequelize = sequelize;
+db.Sequelize = Sequelize;
+
+module.exports = db;


### PR DESCRIPTION
Although sequelize will create the required tables, it is only set up to alter to match model updates in development
This update allows migration using the `npx sequelize-cli db:migrate` and `npx sequelize-cli db:migrate:undo` commands