### PR TITLE
feat: /master-channel edit command, %M for naming scheme

### DIFF
--- a/src/discord/listeners/autocomplete/MasterChannelAutocomplete.ts
+++ b/src/discord/listeners/autocomplete/MasterChannelAutocomplete.ts
@@ -1,0 +1,36 @@
+import {ApplicationCommandOptionChoiceData, AutocompleteInteraction, Events} from "discord.js";
+import Listener, {ListenerType} from "../../../lib/interfaces/Listener";
+import logger from "../../../logger";
+import twineChannelManager from "../../../lib/managers/TwineChannelManager";
+import {DiscordChannelType} from "../../../lib/sequelize/models/discordchannel.model";
+
+export default class MasterChannelAutocomplete implements Listener<Events.InteractionCreate> {
+    type = ListenerType.ON;
+
+    event = Events.InteractionCreate;
+
+    async execute(interaction: AutocompleteInteraction): Promise<void> {
+        if (!interaction.isAutocomplete()) return;
+
+        const focusedOption = interaction.options.getFocused(true);
+        logger.info(focusedOption.name);
+        if (focusedOption.name !== "master-channel") return;
+
+        const matchingChannels = twineChannelManager.getChannels().filter(
+            x =>
+                x.discord.guildId === interaction.guildId &&
+                x.type === DiscordChannelType.MASTER_CHANNEL &&
+                x.name.toLowerCase().includes(focusedOption.value.toLowerCase())
+        );
+
+        let options: ApplicationCommandOptionChoiceData[] = matchingChannels.map(x => {
+            return {
+                name: `🔈 ${x.name}`,
+                value: x.id,
+            }
+        });
+
+        await interaction.respond(options);
+    }
+
+}

--- a/src/discord/listeners/index.ts
+++ b/src/discord/listeners/index.ts
@@ -12,8 +12,11 @@ import MessageDeleteListener from "./message/MessageDeleteListener";
 import VoiceListener from "./voice/VoiceListener";
 
 import ReadyListener from "./ReadyListener";
+import MasterChannelAutocomplete from "./autocomplete/MasterChannelAutocomplete";
 
 const listeners: Listener<any>[] = [
+    new MasterChannelAutocomplete(),
+
     new ChannelDeleteListener(),
     new ChannelUpdateListener(),
 

--- a/src/discord/slashCommands/master-channel/CreateSubcommand.ts
+++ b/src/discord/slashCommands/master-channel/CreateSubcommand.ts
@@ -17,7 +17,7 @@ export default class CreateSubcommand implements TwineSubcommand {
         )
         .addStringOption(option => option
             .setName("naming-scheme")
-            .setDescription("Naming scheme for child channels. Use %N for channel number (e.g. '🕹️Gaming Channel | %N')")
+            .setDescription("Naming scheme for child channels. Use %N for channel number and %M for owner name")
             .setMinLength(3)
             .setMaxLength(100)
             .setRequired(false)

--- a/src/discord/slashCommands/master-channel/EditSubcommand.ts
+++ b/src/discord/slashCommands/master-channel/EditSubcommand.ts
@@ -1,0 +1,67 @@
+import {ChannelType, ChatInputCommandInteraction, SlashCommandSubcommandBuilder} from "discord.js";
+
+import ReplyManager from "../../../lib/managers/ReplyManager";
+import TwineChannelManager from "../../../lib/managers/TwineChannelManager";
+import TwineSubcommand from "../../../lib/interfaces/commands/TwineSubcommand";
+import twineChannelManager from "../../../lib/managers/TwineChannelManager";
+
+export default class EditSubcommand implements TwineSubcommand {
+    data = new SlashCommandSubcommandBuilder()
+        .setName("edit")
+        .setDescription("Edit an existing master channel")
+        .addStringOption(option => option
+            .setName("master-channel")
+            .setDescription("The master channel to edit")
+            .setAutocomplete(true)
+            .setRequired(true)
+        )
+        .addStringOption(option => option
+            .setName("channel-name")
+            .setDescription("Channel Name")
+            .setMinLength(3)
+            .setMaxLength(30)
+            .setRequired(false)
+        )
+        .addStringOption(option => option
+            .setName("naming-scheme")
+            .setDescription("Naming scheme for child channels. Use %N for channel number (e.g. '🕹️Gaming Channel | %N')")
+            .setMinLength(3)
+            .setMaxLength(100)
+            .setRequired(false)
+        );
+
+    async execute(interaction: ChatInputCommandInteraction, replyManager: ReplyManager<ChatInputCommandInteraction>): Promise<void> {
+        const masterChannelId = interaction.options.getString("master-channel", true);
+        const channelName = interaction.options.getString("channel-name", false);
+        const namingScheme = interaction.options.getString("naming-scheme", false);
+
+        if (!channelName && !namingScheme) {
+            await replyManager.error(`You must specify either a new channel name or a new naming scheme!`);
+            return;
+        }
+
+        const masterChannel = twineChannelManager.getChannel(masterChannelId);
+        if (!masterChannel) {
+            await replyManager.error(`Could not find master channel with ID ${masterChannelId}`);
+            return;
+        }
+
+        let result = [`**Successfully updated master channel <#${masterChannel.id}>!**`,""];
+
+        if (channelName) {
+            await masterChannel.discord.edit({
+                name: channelName,
+            });
+            result.push(`- Channel name was updated to \`${channelName}\``);
+        }
+
+        if (namingScheme) {
+            masterChannel.database.namingScheme = namingScheme;
+            await masterChannel.database.save();
+            result.push(`- Naming scheme was updated to \`${namingScheme}\``);
+        }
+
+        await replyManager.success(result.join("\n"));
+    }
+
+}

--- a/src/discord/slashCommands/master-channel/EditSubcommand.ts
+++ b/src/discord/slashCommands/master-channel/EditSubcommand.ts
@@ -1,7 +1,6 @@
-import {ChannelType, ChatInputCommandInteraction, SlashCommandSubcommandBuilder} from "discord.js";
+import {ChatInputCommandInteraction, SlashCommandSubcommandBuilder} from "discord.js";
 
 import ReplyManager from "../../../lib/managers/ReplyManager";
-import TwineChannelManager from "../../../lib/managers/TwineChannelManager";
 import TwineSubcommand from "../../../lib/interfaces/commands/TwineSubcommand";
 import twineChannelManager from "../../../lib/managers/TwineChannelManager";
 
@@ -24,7 +23,7 @@ export default class EditSubcommand implements TwineSubcommand {
         )
         .addStringOption(option => option
             .setName("naming-scheme")
-            .setDescription("Naming scheme for child channels. Use %N for channel number (e.g. '🕹️Gaming Channel | %N')")
+            .setDescription("Naming scheme for child channels. Use %N for channel number and %M for owner name")
             .setMinLength(3)
             .setMaxLength(100)
             .setRequired(false)

--- a/src/discord/slashCommands/master-channel/index.ts
+++ b/src/discord/slashCommands/master-channel/index.ts
@@ -3,6 +3,7 @@ import {SlashCommandBuilder, InteractionContextType, PermissionFlagsBits} from "
 import TwineCommandWithSubcommands from "../../../lib/interfaces/commands/TwineCommandWithSubcommands";
 
 import CreateSubcommand from "./CreateSubcommand";
+import EditSubcommand from "./EditSubcommand";
 
 export default class MasterChannelCommand extends TwineCommandWithSubcommands {
 
@@ -13,6 +14,7 @@ export default class MasterChannelCommand extends TwineCommandWithSubcommands {
             .setContexts(InteractionContextType.Guild)
             .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild), [
                 new CreateSubcommand(),
+                new EditSubcommand(),
         ]);
     }
 

--- a/src/lib/managers/TwineChannelManager.ts
+++ b/src/lib/managers/TwineChannelManager.ts
@@ -60,6 +60,10 @@ class TwineChannelManager {
         return this.channels.get(id);
     }
 
+    getChannels(): Collection<string, ManagedChannel> {
+        return this.channels;
+    }
+
     async deleteChannel(id: string): Promise<ManagedChannel|null> {
         const channel = this.channels.get(id);
         if (channel) {


### PR DESCRIPTION
Adds /master-channel edit command to change the naming scheme of an existing master channel plus %M to display the owner's username in the channel scheme